### PR TITLE
Fix #6: Add Biome lint and format commands to mise configuration with CLAUDE.md automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Project Instructions for Claude
+
+## Code Quality Checks
+When you have completed implementation tasks in this project, ALWAYS run the following command before finalizing:
+```bash
+mise run check
+```
+
+This command will:
+- Run Biome linter to check for code quality issues
+- Run Biome formatter to ensure consistent code formatting
+- Automatically fix any issues that can be auto-fixed
+
+## Important Notes
+- This project uses Biome for both linting and formatting
+- All JavaScript/TypeScript files should pass Biome checks
+- The configuration is defined in biome.json

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -12,14 +10,24 @@
         "useArrowFunction": "error"
       },
       "style": {
-        "noVar": "error",
         "useConst": "error",
         "useTemplate": "error",
-        "useNodejsImportProtocol": "error"
+        "useNodejsImportProtocol": "error",
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
       },
       "suspicious": {
         "noExplicitAny": "error",
-        "noArrayIndexKey": "error"
+        "noArrayIndexKey": "error",
+        "noVar": "error"
       },
       "correctness": {
         "noUnusedVariables": "error"
@@ -38,12 +46,12 @@
     "formatter": {
       "quoteStyle": "single",
       "jsxQuoteStyle": "double",
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "semicolons": "asNeeded",
       "arrowParentheses": "always"
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", "coverage", ".git"]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/coverage", "!**/.git"]
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[tools]
+node = "22"
+biome = "latest"
+
+[tasks.lint]
+run = "biome lint ."
+description = "Run Biome linter"
+
+[tasks.format]
+run = "biome format --write ."
+description = "Format code with Biome"
+
+[tasks.check]
+run = "biome check --write ."
+description = "Run Biome lint and format"

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,28 +6,28 @@ if (app) {
   // コンテナを作成
   const container = document.createElement('div')
   container.className = 'container'
-  
+
   // h1要素を作成
   const heading = document.createElement('h1')
   heading.textContent = 'Hello World!'
-  
+
   // p要素を作成
   const paragraph = document.createElement('p')
   paragraph.textContent = 'Welcome to your Vite-powered application'
-  
+
   // ボタンを作成
   const button = document.createElement('button')
   button.id = 'counter'
   button.type = 'button'
   button.textContent = 'Count is 0'
-  
+
   // カウンター機能を実装
   let count = 0
   button.addEventListener('click', () => {
     count++
     button.textContent = `Count is ${count}`
   })
-  
+
   // DOM要素を構築
   container.appendChild(heading)
   container.appendChild(paragraph)

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,6 @@
 :root {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
Fixes #6

## 対応内容
- mise.tomlにBiomeタスクを追加（lint、format、check）
- CLAUDE.mdファイルを作成し、実装完了時のBiome check自動実行を指示
- 既存のbiome.jsonとの整合性を確保